### PR TITLE
break out of loop in GetModuleHandle

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dinvk"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 description = "Dynamically invoke arbitrary code and use various tricks written idiomatically in Rust (Dinvoke)"
 license = "MIT"

--- a/src/address/mod.rs
+++ b/src/address/mod.rs
@@ -39,6 +39,9 @@ where
         let mut data_table_entry = (*ldr_data).InMemoryOrderModuleList.Flink as *const LDR_DATA_TABLE_ENTRY;
         let mut list_node = (*ldr_data).InMemoryOrderModuleList.Flink;
 
+        // Save a reference to the head nod for the list
+        let head_node = list_node;
+
         if module.to_string().is_empty() {
             return (*data_table_entry).Reserved2[0];
         }
@@ -67,6 +70,12 @@ where
 
             // Moves to the next node in the list of modules
             list_node = (*list_node).Flink;
+
+            // Break out of loop if all of the nodes have been checked
+            if list_node == head_node {
+                break
+            }
+
             data_table_entry = list_node as *const LDR_DATA_TABLE_ENTRY
         }
     }


### PR DESCRIPTION
When coffeeldr was compiled with mingw `GetModuleHandle` would get stuck in the while loop looking for MSVCRT.

Looks like  LDR_DATA_TABLE is a doubly linked list. [1]

This change keeps track of the head node and breaks out of the loop if the head node is hit again.

[1] https://learn.microsoft.com/en-us/windows-hardware/drivers/kernel/singly-and-doubly-linked-lists